### PR TITLE
Loading Screen Implementation

### DIFF
--- a/Positively Dead/Assets/Prefabs.meta
+++ b/Positively Dead/Assets/Prefabs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fbe3d878e3c594b4cb6b63fc8d07224e
+guid: 4a49bdad8f0b98d409672cea1eb362bd
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Positively Dead/Assets/Prefabs/LoadingPanel.prefab
+++ b/Positively Dead/Assets/Prefabs/LoadingPanel.prefab
@@ -1,0 +1,158 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1538859189198140}
+  m_IsPrefabAsset: 1
+--- !u!1 &1538859189198140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224599099457549072}
+  - component: {fileID: 222853961284873480}
+  - component: {fileID: 114991018709649512}
+  m_Layer: 5
+  m_Name: LoadingPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1859717920279376
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224767272685673832}
+  - component: {fileID: 222607070966236498}
+  - component: {fileID: 114583594208845462}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &114583594208845462
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1859717920279376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: ff98e58544ea7804296c0bcc39b7de33, type: 3}
+    m_FontSize: 102
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 102
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Loading...
+--- !u!114 &114991018709649512
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1538859189198140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &222607070966236498
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1859717920279376}
+  m_CullTransparentMesh: 0
+--- !u!222 &222853961284873480
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1538859189198140}
+  m_CullTransparentMesh: 0
+--- !u!224 &224599099457549072
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1538859189198140}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224767272685673832}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224767272685673832
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1859717920279376}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224599099457549072}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 701, y: -467}
+  m_SizeDelta: {x: 445.7, y: 133.8}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Positively Dead/Assets/Prefabs/LoadingPanel.prefab.meta
+++ b/Positively Dead/Assets/Prefabs/LoadingPanel.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3392df176e49c4479a9982599b3edfe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Positively Dead/Assets/Scenes/Island 1 - NORSE.unity
+++ b/Positively Dead/Assets/Scenes/Island 1 - NORSE.unity
@@ -361,6 +361,106 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &334931087
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1658234367}
+    m_Modifications:
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a3392df176e49c4479a9982599b3edfe, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &491420139
 GameObject:
   m_ObjectHideFlags: 0
@@ -894,6 +994,12 @@ RectTransform:
   m_AnchoredPosition: {x: 367.1, y: -464.1}
   m_SizeDelta: {x: 431.9, y: 81}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1292599976 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114583594208845462, guid: a3392df176e49c4479a9982599b3edfe,
+    type: 2}
+  m_PrefabInternal: {fileID: 334931087}
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
 --- !u!1 &1408653936
 GameObject:
   m_ObjectHideFlags: 0
@@ -1259,6 +1365,7 @@ RectTransform:
   - {fileID: 1248130085}
   - {fileID: 915504193}
   - {fileID: 1415935829}
+  - {fileID: 1813125421}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1342,6 +1449,16 @@ Transform:
   m_Father: {fileID: 1658234367}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1813125420 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1538859189198140, guid: a3392df176e49c4479a9982599b3edfe,
+    type: 2}
+  m_PrefabInternal: {fileID: 334931087}
+--- !u!224 &1813125421 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224599099457549072, guid: a3392df176e49c4479a9982599b3edfe,
+    type: 2}
+  m_PrefabInternal: {fileID: 334931087}
 --- !u!1 &1977726850
 GameObject:
   m_ObjectHideFlags: 0
@@ -1354,6 +1471,7 @@ GameObject:
   - component: {fileID: 1977726852}
   - component: {fileID: 1977726853}
   - component: {fileID: 1977726851}
+  - component: {fileID: 1977726856}
   m_Layer: 5
   m_Name: DialogueBox
   m_TagString: Untagged
@@ -1453,3 +1571,17 @@ RectTransform:
   m_AnchoredPosition: {x: -1.8, y: -301.95}
   m_SizeDelta: {x: 1681.7, y: 195.5}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1977726856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1977726850}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ab8784571b3bd04d82cc9e2a675faf6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scene: NorseMinigame
+  loadingText: {fileID: 1292599976}
+  loadingPanel: {fileID: 1813125420}

--- a/Positively Dead/Assets/Scripts/DialogueManager.cs
+++ b/Positively Dead/Assets/Scripts/DialogueManager.cs
@@ -19,6 +19,8 @@ public class DialogueManager : MonoBehaviour {
     //The current dialogue node
     private Dialogue currentDialogue;
 
+    private OpenScene loadSceneManager;
+
     [SerializeField]
     private string sceneName;
 
@@ -43,6 +45,7 @@ public class DialogueManager : MonoBehaviour {
 	// Use this for initialization
 	void Start () {
         typer = gameObject.GetComponent<Typewriter>();
+        loadSceneManager = gameObject.GetComponent<OpenScene>();
         button1.SetActive(false);
         button2.SetActive(false);
 
@@ -153,7 +156,7 @@ public class DialogueManager : MonoBehaviour {
         //If this is the end of the scene, then load the next unity scene
         if (currentDialogue.EndsScene)
         {
-            SceneManager.LoadScene(nextScene);
+            loadSceneManager.TriggerLoad(nextScene);
         }
         else
         {

--- a/Positively Dead/Assets/Scripts/OpenScene.cs
+++ b/Positively Dead/Assets/Scripts/OpenScene.cs
@@ -1,0 +1,76 @@
+﻿using UnityEngine;
+using System.Collections;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+/// <summary>
+/// Handles all scene transitions in the game.
+/// Author: Nikolas Whiteside
+/// Date: 10/12/2018
+/// </summary>
+public class OpenScene : MonoBehaviour {
+
+    private bool loadScene = false;
+
+    [SerializeField]
+    private string scene;
+
+    [SerializeField]
+    private Text loadingText;
+
+    [SerializeField]
+    private GameObject loadingPanel;
+
+    void Start()
+    {
+        loadingPanel.SetActive(false);
+    }
+
+    IEnumerator LoadScene() {
+        yield return new WaitForSeconds(3);
+
+        AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(scene);
+
+        while(!asyncLoad.isDone) {
+            yield return null;
+        }
+    }
+
+    /// <summary>
+    /// Triggers a loading screen with the original scene name
+    /// </summary>
+    public void TriggerLoad()
+    {
+        if (!loadScene)
+        {
+            loadScene = true;
+            loadingPanel.SetActive(true);
+            loadingText.text = "Loading...";
+            StartCoroutine(LoadScene());
+        }
+    }
+
+    /// <summary>
+    /// Updates the scene name and triggers a loading screen
+    /// </summary>
+    /// <param name="scene"></param>
+    public void TriggerLoad(string scene)
+    {
+        this.scene = scene;
+        if (!loadScene)
+        {
+            loadScene = true;
+            loadingPanel.SetActive(true);
+            loadingText.text = "Loading...";
+            StartCoroutine(LoadScene());
+        }
+    }
+
+	/// <summary>
+	/// Toggles the display of a canvas on or off.
+	/// </summary>
+	/// <param name="canvasName">The canvas to display.</param>
+	public void DisplayCanvas(Canvas myCanvas) {
+		myCanvas.gameObject.SetActive (!myCanvas.gameObject.activeInHierarchy);
+	}
+}

--- a/Positively Dead/Assets/Scripts/OpenScene.cs.meta
+++ b/Positively Dead/Assets/Scripts/OpenScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ab8784571b3bd04d82cc9e2a675faf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implements Loading Screens
-Integrates OpenScene script into project.
-Creates panel in Norse Island Dialogue scene for loading.
-OpenScene TriggerLoad() method is called from DialogueManager. This method Triggers an asynchronous load of the desired scene and enables a panel in the canvas that stands as a loading screen.
-This PR does not integrate this onto every page, it is simply a proof of concept. Full integration with the game will take place once loading screen assets are finished.
-It may be difficult to see the panel being triggered because loading between our scenes happens so fast - so just be aware of that.